### PR TITLE
RK-9709 - More opentracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ copy the url address from terminal #3 and browse to it
 
 ### developing
 while `minikube dashboard` and `skaffold dev` are up, you can save changes into the code, and after ~30 seconds refresh the app in the browser.
+
+if you wish to connect a service to rookout, go to `kubernetes-manifests/[the service name].yaml`
+and under the `env` attribute add:
+```yaml
+env:
+  - name: ROOKOUT_CONTROLLER_HOST
+    value: '[controller-url]'
+  - name: ROOKOUT_CONTROLLER_PORT
+    value: '443'
+  - name: ROOKOUT_TOKEN
+    value: '[your rookout org token]'
+  - name: ROOKOUT_LABELS
+    value: 'app:microservices-demo,microservice:[the service name]'
+  - name: ROOKOUT_REMOTE_ORIGIN
+    value: "https://github.com/rookout/microservices-demo.git"
+  - name: ROOKOUT_DEBUG
+    value: "1"
+```
 _______________________________
 
 

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -35,10 +35,6 @@ spec:
         env:
         - name: PORT
           value: "8080"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -45,12 +45,6 @@ spec:
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice:3550"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
         resources:
           requests:
             cpu: 100m

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -21,10 +21,6 @@ RUN apt-get -qq update \
         g++ \
     && rm -rf /var/lib/apt/lists/*
 
-# get packages
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
 FROM base as final
 # Enable unbuffered logging
 ENV PYTHONUNBUFFERED=1
@@ -41,6 +37,14 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     chmod +x /bin/grpc_health_probe
 
 WORKDIR /email_server
+
+# pip installing the requirements.txt requires git because we're installing a fork
+RUN apt-get -y update
+RUN apt-get -y install git
+
+# get packages
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 
 # Grab packages from builder
 COPY --from=builder /usr/local/lib/python3.7/ /usr/local/lib/python3.7/

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -7,4 +7,4 @@ requests==2.24.0
 rook>=0.1.146
 opentracing==2.4.0
 jaeger-client==4.5.0
--e git://github.com/Rookout/python-grpc.git@edd56200af4bb1ebfefa347686102c6dd1a33754#egg=grpcio_opentracing
+-e git://github.com/Rookout/python-grpc.git@35b7456cdc7a91d743f29492e67429fce7f27963#egg=grpcio_opentracing

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -5,5 +5,6 @@ jinja2==2.11.3
 python-json-logger==0.1.11
 requests==2.24.0
 rook>=0.1.146
-jaeger-client
-grpcio-opentracing
+opentracing==2.4.0
+jaeger-client==4.5.0
+-e git://github.com/Rookout/python-grpc.git@edd56200af4bb1ebfefa347686102c6dd1a33754#egg=grpcio_opentracing

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -24,8 +24,13 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 
-# get packages
 WORKDIR /recommendationservice
+
+# pip installing the requirements.txt requires git because we're installing a fork
+RUN apt-get -y update
+RUN apt-get -y install git
+
+# get packages
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -1,10 +1,9 @@
 google-api-core==1.23.0
 grpcio-health-checking==1.33.2
 grpcio==1.33.2
-opencensus==0.7.11
-opencensus-ext-stackdriver==0.7.3
-opencensus-ext-grpc==0.7.1
 python-json-logger==0.1.11
-google-cloud-profiler==1.1.2
 requests==2.24.0
 rook>=0.1.146
+opentracing==2.4.0
+jaeger-client==4.5.0
+-e git://github.com/Rookout/python-grpc.git@35b7456cdc7a91d743f29492e67429fce7f27963#egg=grpcio_opentracing


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42871571/123066621-e6b72d00-d418-11eb-832e-f44e16ccc785.png)


1. email service -- openTracing is now collected by Rookout, since we're using our form of openTracing-python-grpc repo.
2. span context baggage now includes fields. (screenshot above) from the same reason.
3. recommendation service -  added tracing to as well.