### PR TITLE
RK-9802 - bump java sdk version

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -105,7 +105,7 @@ task downloadRepos(type: Copy) {
 }
 
 task downloadRookout(type: Download) {
-    sourceUrl = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=0.1.179"
+    sourceUrl = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=0.1.180"
     target = new File('rook.jar')
 }
 


### PR DESCRIPTION
the script for auto-bumping the rook version in the java microserice didn't work in the last time.
i think I already fixed it, we'll know only on the next rook publish.
but for now, the latest rook release fix a critical livetail bug, so I'm bumping it manualy.