### PR TITLE
RK-10792 - replace python with explicit python3

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++ 
 


### PR DESCRIPTION
Getting this when building the images:
```
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
The command '/bin/sh -c apk add --update --no-cache     python     make     g++' returned a non-zero code: 1
make: *** [Makefile:10: build] Error 1
```
 need python3 explicitly (build image locally with great success after changing)