### PR TITLE
RK-11103 - upgrade log4j core for log4shell mitigation round 2

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -37,7 +37,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.15.0",
+                "org.apache.logging.log4j:log4j-core:2.17.0",
                 "io.opentracing:opentracing-api:0.33.0",
                 "io.opentracing.contrib:opentracing-grpc:0.2.3",
                 "io.jaegertracing:jaeger-client:1.6.0"


### PR DESCRIPTION
## please make sure to define your merge request to rookout/microservices-demo:master instead of the default GoogleCloudPlatform/microservices-demo:master 
https://www.zdnet.com/article/apache-releases-new-2-17-0-patch-for-log4j-to-solve-denial-of-service-vulnerability/