### PR TITLE
RK-11651 - Make Skaffold work for K8s deoployment

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -35,6 +35,11 @@ spec:
         env:
         - name: PORT
           value: "9555"
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         resources:
           requests:
             cpu: 200m

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -33,6 +33,11 @@ spec:
         ports:
         - containerPort: 7070
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: REDIS_ADDR
           value: "redis-cart:6379"
         resources:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -27,46 +27,51 @@ spec:
     spec:
       serviceAccountName: default
       containers:
-        - name: server
-          image: checkoutservice
-          ports:
-          - containerPort: 5050
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
-          env:
-          - name: PORT
-            value: "5050"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: "productcatalogservice:3550"
-          - name: SHIPPING_SERVICE_ADDR
-            value: "shippingservice:50051"
-          - name: PAYMENT_SERVICE_ADDR
-            value: "paymentservice:50051"
-          - name: EMAIL_SERVICE_ADDR
-            value: "emailservice:5000"
-          - name: CURRENCY_SERVICE_ADDR
-            value: "currencyservice:7000"
-          - name: CART_SERVICE_ADDR
-            value: "cartservice:7070"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+      - name: server
+        image: checkoutservice
+        ports:
+        - containerPort: 5050
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:5050"]
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:5050"]
+        env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
+        - name: PORT
+          value: "5050"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: PAYMENT_SERVICE_ADDR
+          value: "paymentservice:50051"
+        - name: EMAIL_SERVICE_ADDR
+          value: "emailservice:5000"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        # - name: DISABLE_STATS
+        #   value: "1"
+        # - name: DISABLE_TRACING
+        #   value: "1"
+        # - name: DISABLE_PROFILER
+        #   value: "1"
+        # - name: JAEGER_SERVICE_ADDR
+        #   value: "jaeger-collector:14268"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -34,6 +34,11 @@ spec:
         - name: grpc
           containerPort: 7000
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "7000"
         # - name: DISABLE_TRACING

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -33,6 +33,11 @@ spec:
         ports:
         - containerPort: 8080
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "8080"
         readinessProbe:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -50,6 +50,11 @@ spec:
               - name: "Cookie"
                 value: "shop_session-id=x-liveness-probe"
           env:
+          - name: ROOKOUT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: rookout
+                key: token
           - name: PORT
             value: "8080"
           - name: PRODUCT_CATALOG_SERVICE_ADDR

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -34,6 +34,11 @@ spec:
       - name: main
         image: loadgenerator
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: FRONTEND_ADDR
           value: "frontend:80"
         - name: USERS

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -33,6 +33,11 @@ spec:
         ports:
         - containerPort: 50051
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "50051"
         readinessProbe:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -33,6 +33,11 @@ spec:
         ports:
         - containerPort: 3550
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "3550"
         # - name: DISABLE_STATS

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -41,6 +41,11 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR

--- a/kubernetes-manifests/secrets.yaml
+++ b/kubernetes-manifests/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rookout
+type: Opaque
+stringData:
+  token: TOKEN_GOES_HERE

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -32,6 +32,11 @@ spec:
         ports:
         - containerPort: 50051
         env:
+        - name: ROOKOUT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rookout
+              key: token
         - name: PORT
           value: "50051"
         # - name: DISABLE_STATS

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,20 +16,25 @@ apiVersion: skaffold/v1beta2
 kind: Config
 build:
   artifacts:
-  # image tags are relative; to specify an image repo (e.g. GCR), you
-  # must provide a "default repo" using one of the methods described
-  # here:
-  # https://skaffold.dev/docs/concepts/#image-repository-handling
   - image: emailservice
     context: src/emailservice
   - image: productcatalogservice
     context: src/productcatalogservice
+    docker:
+      buildArgs:
+        ARTIFACTORY_CREDS: '{{ .ARTIFACTORY_CREDS }}'
   - image: recommendationservice
     context: src/recommendationservice
   - image: shippingservice
     context: src/shippingservice
+    docker:
+      buildArgs:
+        ARTIFACTORY_CREDS: '{{ .ARTIFACTORY_CREDS }}'
   - image: checkoutservice
     context: src/checkoutservice
+    docker:
+      buildArgs:
+        ARTIFACTORY_CREDS: '{{ .ARTIFACTORY_CREDS }}'
   - image: paymentservice
     context: src/paymentservice
   - image: currencyservice
@@ -38,6 +43,9 @@ build:
     context: src/cartservice/src
   - image: frontend
     context: src/frontend
+    docker:
+      buildArgs:
+        ARTIFACTORY_CREDS: '{{ .ARTIFACTORY_CREDS }}'
   - image: adservice
     context: src/adservice
   tagPolicy:
@@ -47,6 +55,7 @@ build:
 deploy:
   kubectl:
     manifests:
+      - ./kubernetes-manifests/secrets.yaml
       - ./kubernetes-manifests/adservice.yaml
       - ./kubernetes-manifests/cartservice.yaml
       - ./kubernetes-manifests/checkoutservice.yaml
@@ -58,18 +67,3 @@ deploy:
       - ./kubernetes-manifests/recommendationservice.yaml
       - ./kubernetes-manifests/redis.yaml
       - ./kubernetes-manifests/shippingservice.yaml
-profiles:
-# "gcb" profile allows building and pushing the images
-# on Google Container Builder without requiring docker
-# installed on the developer machine. However, note that
-# since GCB does not cache the builds, each build will
-# start from scratch and therefore take a long time.
-#
-# This is not used by default. To use it, run:
-#     skaffold run -p gcb
-- name: gcb
-  build:
-    googleCloudBuild:
-      diskSizeGb: 300
-      machineType: N1_HIGHCPU_32
-      timeout: 4000s

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -1,7 +1,7 @@
 google-api-core==1.24.1
 grpcio-health-checking==1.33.2
 grpcio==1.33.2
-jinja2==2.11.3
+jinja2==3.0.3
 python-json-logger==0.1.11
 requests==2.24.0
 rook>=0.1.163


### PR DESCRIPTION
1. Updated the jinja2 package because I got an error with the older version
2. Added a secret for the ROOKOUT_TOKEN, added it as a variable to all deployments
3. Added the ARTIFACTORY_CREDS variable to the build process of the relevant services

To deploy to a local K8s cluster set the token in "secrets.yaml" then run `ARTIFACTORY_CREDS=[creds] skaffold dev`