### PR TITLE
RK-20294 - upgrade to go1.18

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 RUN apk --update --no-cache add curl make git gcc musl-dev protobuf-dev openssl-libs-static openssl-dev build-base zlib-static
 
 ENV GO111MODULE=on
@@ -26,7 +26,7 @@ RUN go mod download
 
 RUN go build -tags=${GOROOK_OS_TAG},rookout_static -gcflags="all=-dwarflocationlists=true" -o /checkoutservice .
 
-FROM golang:1.17-alpine as release
+FROM golang:1.18-alpine as release
 RUN apk add --update --no-cache ca-certificates
 
 ARG GIT_COMMIT=unspecified

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 RUN apk --update --no-cache add curl make git gcc musl-dev protobuf-dev openssl-libs-static openssl-dev build-base zlib-static
 
 ENV GO111MODULE=on
@@ -24,7 +24,7 @@ COPY . .
 RUN go mod download
 RUN go build -tags=${GOROOK_OS_TAG},rookout_static -gcflags="all=-dwarflocationlists=true" -o /go/bin/frontend .
 
-FROM golang:1.17-alpine as release
+FROM golang:1.18-alpine as release
 RUN apk add --update --no-cache ca-certificates
 
 ARG GIT_COMMIT=unspecified

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 RUN apk --update --no-cache add curl make git gcc musl-dev protobuf-dev openssl-libs-static openssl-dev build-base zlib-static
 
 ENV GO111MODULE=on
@@ -23,7 +23,7 @@ COPY . .
 RUN go mod download
 RUN go build -tags=${GOROOK_OS_TAG},rookout_static -gcflags="all=-dwarflocationlists=true" -o /go/bin/productcatalogservice .
 
-FROM golang:1.17-alpine AS release
+FROM golang:1.18-alpine AS release
 RUN apk add --update --no-cache ca-certificates
 
 ARG GIT_COMMIT=unspecified

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 RUN apk --update --no-cache add curl make git gcc musl-dev protobuf-dev openssl-libs-static openssl-dev build-base zlib-static
 
 ENV GO111MODULE=on
@@ -24,7 +24,7 @@ RUN go mod download
 
 RUN go build -tags=${GOROOK_OS_TAG},rookout_static -gcflags="all=-dwarflocationlists=true" -o /go/bin/shippingservice
 
-FROM golang:1.17-alpine AS release
+FROM golang:1.18-alpine AS release
 RUN apk add --update --no-cache ca-certificates
 
 ARG GIT_COMMIT=unspecified


### PR DESCRIPTION
## please make sure to define your merge request to rookout/microservices-demo:master instead of the default GoogleCloudPlatform/microservices-demo:master 

Got a build error and looks like http2 is complaining about go version...

19.34 /go/pkg/mod/golang.org/x/net@v0.20.0/http2/transport.go:1021:13: tc.NetConn undefined (type *tls.Conn has no field or method NetConn)
19.34 note: module requires Go 1.18